### PR TITLE
Add ethernet support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,25 @@ ifneq ($(DEBUG),)
 EXTRA_ARGS +=--debug_level $(DEBUG)
 endif
 
+# System parameters
+ifneq ($(INIT_MEM),)
+PY_PARAMS:=$(PY_PARAMS):init_mem=$(INIT_MEM)
+endif
+ifneq ($(USE_INTMEM),)
+PY_PARAMS:=$(PY_PARAMS):use_intmem=$(USE_INTMEM)
+endif
+ifneq ($(USE_EXTMEM),)
+PY_PARAMS:=$(PY_PARAMS):use_extmem=$(USE_EXTMEM)
+endif
+ifneq ($(USE_ETHERNET),)
+PY_PARAMS:=$(PY_PARAMS):use_ethernet=$(USE_ETHERNET)
+endif
+# Remove first char (:) from PY_PARAMS
+PY_PARAMS:=$(shell echo $(PY_PARAMS) | cut -c2-)
+
+
 setup:
-	nix-shell --run "py2hwsw $(CORE) setup --no_verilog_lint --py_params 'use_intmem=$(USE_INTMEM):use_extmem=$(USE_EXTMEM):init_mem=$(INIT_MEM)' $(EXTRA_ARGS)"
+	nix-shell --run "py2hwsw $(CORE) setup --no_verilog_lint --py_params '$(PY_PARAMS)' $(EXTRA_ARGS)"
 
 pc-emul-run:
 	nix-shell --run "make clean setup && make -C ../$(CORE)_V$(VERSION)/ pc-emul-run"

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The bootloader and firmware provided use ethernet to speed up file transfers.
 
 However, to setup the ethernet interfaces on the host machine, root privileges are required.
 As an alternative, ethernet can be disable by passing `USE_ETHERNET=0` to the make command.
-This will cause SocLinux to generate a system without ethernet support, and make all file transfers via serial communication.
+This will cause SoCLinux to generate a system without ethernet support, and make all file transfers via serial communication.
 
 ## Ethernet simulation
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The bootloader in SoCLinux differs from that in IOb-SoC. In SoCLinux, the bootlo
 The boot control unit in SoCLinux, unlike IOb-SoC, is a distinct module and exclusively manages the boot process state. On the software side, the SoCLinux bootloader initially loads a file named soc_linux_mem.config, which specifies the files and their respective memory addresses to be copied into external memory.
 
 -->
+
 ## Ethernet
 
 The SoCLinux template supports ethernet communication by default.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The SoCLinux template supports ethernet communication by default.
 The bootloader and firmware provided use ethernet to speed up file transfers.
 
 However, to setup the ethernet interfaces on the host machine, root privileges are required.
-As an alternative, ethernet can be disable by passing `USE_ETHERNET=0` to the make command.
+As an alternative, ethernet can be disabled by passing `USE_ETHERNET=0` to the make command.
 This will cause SoCLinux to generate a system without ethernet support, and make all file transfers via serial communication.
 
 ## Ethernet simulation

--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ The bootloader in SoCLinux differs from that in IOb-SoC. In SoCLinux, the bootlo
 The boot control unit in SoCLinux, unlike IOb-SoC, is a distinct module and exclusively manages the boot process state. On the software side, the SoCLinux bootloader initially loads a file named soc_linux_mem.config, which specifies the files and their respective memory addresses to be copied into external memory.
 
 -->
+## Ethernet
+
+The SoCLinux template supports ethernet communication by default.
+The bootloader and firmware provided use ethernet to speed up file transfers.
+
+However, to setup the ethernet interfaces on the host machine, root privileges are required.
+As an alternative, ethernet can be disable by passing `USE_ETHERNET=0` to the make command.
+This will cause SocLinux to generate a system without ethernet support, and make all file transfers via serial communication.
+
 ## Ethernet simulation
 
 The ethernet simulation requires dummy interfaces, named `eth-[SIMULATOR]`.

--- a/README.md
+++ b/README.md
@@ -51,13 +51,15 @@ The bootloader in SoCLinux differs from that in IOb-SoC. In SoCLinux, the bootlo
 
 The boot control unit in SoCLinux, unlike IOb-SoC, is a distinct module and exclusively manages the boot process state. On the software side, the SoCLinux bootloader initially loads a file named soc_linux_mem.config, which specifies the files and their respective memory addresses to be copied into external memory.
 
-<!--
-TODO: automate this in Makefile
+-->
 ## Ethernet simulation
 
-The ethernet simulation requires setting up dummy interfaces with
-`eth-[SIMULATOR]` that require `sudo`:
-Setup the following interfaces with the commands:
+The ethernet simulation requires dummy interfaces, named `eth-[SIMULATOR]`.
+
+The SoCLinux template automatically creates Makefiles in the build directory to create these interfaces during the build process for simulation.
+These interfaces require root privileges to be created, so the Makefile may request for sudo/root password during the build process for simulation.
+
+Alternatively, to setup these dummy interfaces manually, run the following commands:
 ```bash
 sudo modprobe dummy
 sudo ip link add eth-icarus type dummy
@@ -102,12 +104,32 @@ sudo ip link set [interface] promisc on
 The system's Python scripts need RAW frame access for Ethernet communication.
 To achieve this, the Python interpreter must have the CAP_NET_RAW capability.
 
-The 'ETHERNET' submodule already includes a Python wrapper that provides RAW frame access.
-To build the python wrapper, run:
+The [iob-eth](https://github.com/IObundle/iob-eth/tree/master/scripts/pyRawWrapper) repository includes a wrapper for the Python binary that provides RAW frame access.
+The iob-eth's scripts will copy this wrapper's Makefile and source files to the build directory under the folder `path/to/build/dir/scripts/pyRawWrapper/`.
+
+The SoCLinux template will generate a Makefile in the build directory to automatically create the Python wrapper during the build process for simulation and FPGA.
+
+Alternatively, to build the python wrapper manually, run:
 ```bash
-make -C submodules/ETHERNET/scripts/pyRawWrapper
+make -C ../soc_linux_V*/scripts/pyRawWrapper
 ```
--->
+
+It is also possible to use a custom python wrapper located in a different path by setting the `IOB_CONSOLE_PYTHON_ENV` environment variable:
+```bash
+export IOB_CONSOLE_PYTHON_ENV=/path/to/custom/pyRawWrapper
+```
+
+## Common issues:
+
+```bash
+unable to set iab: Operation not permitted
+```
+
+This error usually appears when the pyRawWrapper does not have the linux 'CAP_NET_RAW' capability set.
+Running the following command with root privileges will set the capability:
+```bash
+setcap cap_net_raw,cap_setpcap=p path/to/pyRawWrapperBinary
+```
 
 # Tutorial: Add New Device Driver
 Checkout [this tutorial](document/device_driver_tutorial.md) for more details on

--- a/default.nix
+++ b/default.nix
@@ -5,8 +5,8 @@
 { pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/24.05.tar.gz") {} }:
 
 let
-  py2hwsw_commit = "88aa0751afe697e5be1254b2fb7b7c007bf1eaa1"; # Replace with the desired commit.
-  py2hwsw_sha256 = "7FzKUAjqYn79G6lX7CWMGAs34PeULTamjV1UChf6EDw="; # Replace with the actual SHA256 hash.
+  py2hwsw_commit = "0ccdf12d197e5746b807a3eaed6922b4209eba37"; # Replace with the desired commit.
+  py2hwsw_sha256 = "khRmu67kRlTqC34Td5LcaiyPXZ5tNzZoLMGpe88beC0="; # Replace with the actual SHA256 hash.
   # Get local py2hwsw root from `PY2HWSW_ROOT` env variable
   py2hwswRoot = builtins.getEnv "PY2HWSW_ROOT";
 

--- a/default.nix
+++ b/default.nix
@@ -5,8 +5,8 @@
 { pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/24.05.tar.gz") {} }:
 
 let
-  py2hwsw_commit = "0ccdf12d197e5746b807a3eaed6922b4209eba37"; # Replace with the desired commit.
-  py2hwsw_sha256 = "khRmu67kRlTqC34Td5LcaiyPXZ5tNzZoLMGpe88beC0="; # Replace with the actual SHA256 hash.
+  py2hwsw_commit = "6393cb57d49a4529e22ff3fd400fd879b8ffbcb2"; # Replace with the desired commit.
+  py2hwsw_sha256 = "Ud2aZo0YsKGNvODtByf25P/PIpan+3voUO7aP5ODu6c="; # Replace with the actual SHA256 hash.
   # Get local py2hwsw root from `PY2HWSW_ROOT` env variable
   py2hwswRoot = builtins.getEnv "PY2HWSW_ROOT";
 

--- a/default.nix
+++ b/default.nix
@@ -5,8 +5,8 @@
 { pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/24.05.tar.gz") {} }:
 
 let
-  py2hwsw_commit = "c4ea097573a8e399b3ee0814004ea46e18d3d4f6"; # Replace with the desired commit.
-  py2hwsw_sha256 = "ZXfn5J9mLLxh/o46ik9syKuDhoFY9NMzdQ/SDDkjXPg="; # Replace with the actual SHA256 hash.
+  py2hwsw_commit = "88aa0751afe697e5be1254b2fb7b7c007bf1eaa1"; # Replace with the desired commit.
+  py2hwsw_sha256 = "7FzKUAjqYn79G6lX7CWMGAs34PeULTamjV1UChf6EDw="; # Replace with the actual SHA256 hash.
   # Get local py2hwsw root from `PY2HWSW_ROOT` env variable
   py2hwswRoot = builtins.getEnv "PY2HWSW_ROOT";
 


### PR DESCRIPTION
- Update py2hwsw, enabling ethernet support on SoCLinux.
  By default ethernet interface is enabled and used to speed up file transfers.
  If needed, set `USE_ETHERNET=0` environment variable to disable ethernet and use only serial interface for file transfers.
- Update README with information and instructions about the ethernet interfaces.