### PR TITLE
Update py2hwsw version

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,11 +2,11 @@
 #
 # SPDX-License-Identifier: MIT
 
-{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/24.05.tar.gz") {} }:
+{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/25.05.tar.gz") {} }:
 
 let
-  py2hwsw_commit = "f5a6d9b44b7694d92c2df685d415f106da4b9f69"; # Replace with the desired commit.
-  py2hwsw_sha256 = "oPj8d27FAjaPWkMbkUDEYsFvasH0uDCj3MfWZ1NOGo0="; # Replace with the actual SHA256 hash.
+  py2hwsw_commit = "6536700fed1b6270f3a79099941d708e9dcdf7d3"; # Replace with the desired commit.
+  py2hwsw_sha256 = "ugHcpiB1BFHB1QScHUFjMtnDjhob7y5k86/VVJmjKqY="; # Replace with the actual SHA256 hash.
   # Get local py2hwsw root from `PY2HWSW_ROOT` env variable
   py2hwswRoot = builtins.getEnv "PY2HWSW_ROOT";
 

--- a/default.nix
+++ b/default.nix
@@ -5,8 +5,8 @@
 { pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/25.05.tar.gz") {} }:
 
 let
-  py2hwsw_commit = "6536700fed1b6270f3a79099941d708e9dcdf7d3"; # Replace with the desired commit.
-  py2hwsw_sha256 = "ugHcpiB1BFHB1QScHUFjMtnDjhob7y5k86/VVJmjKqY="; # Replace with the actual SHA256 hash.
+  py2hwsw_commit = "e3ec0c99271e3320cec61a9efa76758e364c89f2"; # Replace with the desired commit.
+  py2hwsw_sha256 = "kboZVpCDediAF4qaWVeWbsa0bKo4sGtPYtskUdQiLRs="; # Replace with the actual SHA256 hash.
   # Get local py2hwsw root from `PY2HWSW_ROOT` env variable
   py2hwswRoot = builtins.getEnv "PY2HWSW_ROOT";
 

--- a/default.nix
+++ b/default.nix
@@ -5,8 +5,8 @@
 { pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/24.05.tar.gz") {} }:
 
 let
-  py2hwsw_commit = "09ea8ddb6b510e894709653666506caead5a93d2"; # Replace with the desired commit.
-  py2hwsw_sha256 = "iC1Yaeg9NKFIFVwT7o1abXr80ikWZoy6w4TQmIQV3iw="; # Replace with the actual SHA256 hash.
+  py2hwsw_commit = "f5a6d9b44b7694d92c2df685d415f106da4b9f69"; # Replace with the desired commit.
+  py2hwsw_sha256 = "oPj8d27FAjaPWkMbkUDEYsFvasH0uDCj3MfWZ1NOGo0="; # Replace with the actual SHA256 hash.
   # Get local py2hwsw root from `PY2HWSW_ROOT` env variable
   py2hwswRoot = builtins.getEnv "PY2HWSW_ROOT";
 

--- a/soc_linux.py
+++ b/soc_linux.py
@@ -22,7 +22,7 @@ def setup(py_params: dict):
             # "some_iob_system_linux_param": "my_value",
             **py_params,
         },
-        # Every attribute in this dictionary will override/append to the ones of the iob_system_linux parent core.
+        # Every attribute in this dictionary will override/append to the ones of the iob_system_linux parent core
         "board_list": [
             "iob_aes_ku040_db_g",
             "iob_cyclonev_gt_dk",


### PR DESCRIPTION
New version of Py2HWSW includes the `iob_system_linux` parent module with a new root filesystem.
The new rootfs contains a pre-compiled version of the new auto-generated iob_timer kernel module driver and associated user-space functions. It also includes a pre-compiled user-space program to test the iob_timer driver.

The new Py2HWSW version includes changes up to commit: https://github.com/IObundle/py2hwsw/tree/6536700fed1b6270f3a79099941d708e9dcdf7d3