### PR TITLE
Update py2hwsw version

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,8 +5,8 @@
 { pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/25.05.tar.gz") {} }:
 
 let
-  py2hwsw_commit = "e3ec0c99271e3320cec61a9efa76758e364c89f2"; # Replace with the desired commit.
-  py2hwsw_sha256 = "kboZVpCDediAF4qaWVeWbsa0bKo4sGtPYtskUdQiLRs="; # Replace with the actual SHA256 hash.
+  py2hwsw_commit = "479600b84cdc0dc1d83d93ba7d261657f2770a88"; # Replace with the desired commit.
+  py2hwsw_sha256 = "exfN36FvjvRuBulkMbDrs70msta4XyTFz7iQ3dD9AuU="; # Replace with the actual SHA256 hash.
   # Get local py2hwsw root from `PY2HWSW_ROOT` env variable
   py2hwswRoot = builtins.getEnv "PY2HWSW_ROOT";
 

--- a/default.nix
+++ b/default.nix
@@ -5,8 +5,8 @@
 { pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/25.05.tar.gz") {} }:
 
 let
-  py2hwsw_commit = "479600b84cdc0dc1d83d93ba7d261657f2770a88"; # Replace with the desired commit.
-  py2hwsw_sha256 = "exfN36FvjvRuBulkMbDrs70msta4XyTFz7iQ3dD9AuU="; # Replace with the actual SHA256 hash.
+  py2hwsw_commit = "63d81d8a0b6cd97755a652617bb71e4f644ad3eb"; # Replace with the desired commit.
+  py2hwsw_sha256 = "r5UAe5px50z3wXb56Vxn8/kAS/gE5b0MZcU1UTA8Hmc="; # Replace with the actual SHA256 hash.
   # Get local py2hwsw root from `PY2HWSW_ROOT` env variable
   py2hwswRoot = builtins.getEnv "PY2HWSW_ROOT";
 


### PR DESCRIPTION
New version of Py2HWSW includes the iob_system_linux parent module with a new root filesystem.
The new rootfs contains a pre-compiled version of the new auto-generated iob_timer kernel module driver with support for three kernel-user space interfaces: sysfs, dev, and ioctl.
It also includes three pre-compiled user-space programs to test each interface of the iob_timer driver.

The new Py2HWSW version includes changes up to commit: https://github.com/arturum1/py2hwsw/tree/63d81d8a0b6cd97755a652617bb71e4f644ad3eb

## Please create tag `M2.b` after merging this PR