### PR TITLE
Update Py2HWSW; Add Makefile targets to auto-rebuild kernel modules.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,3 +137,6 @@ release-artifacts:
 	tar -czf $(CORE)_V$(VERSION)_INTMEM0_EXTMEM1_INITMEM0.tar.gz ../$(CORE)_V$(VERSION)
 
 .PHONY: release-artifacts
+
+SOC_LINUX_BUILD_DIR:=$(BUILD_DIR)
+include linux_targets.mk

--- a/default.nix
+++ b/default.nix
@@ -5,8 +5,8 @@
 { pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/25.05.tar.gz") {} }:
 
 let
-  py2hwsw_commit = "63d81d8a0b6cd97755a652617bb71e4f644ad3eb"; # Replace with the desired commit.
-  py2hwsw_sha256 = "r5UAe5px50z3wXb56Vxn8/kAS/gE5b0MZcU1UTA8Hmc="; # Replace with the actual SHA256 hash.
+  py2hwsw_commit = "4ce6c2ab15d270b3a0e58c4f2d3cab5c40cfe85a"; # Replace with the desired commit.
+  py2hwsw_sha256 = "Wq9DEjw3Df0PoraZm5v1TL45nNqYueAUdXXeAVkYMy4="; # Replace with the actual SHA256 hash.
   # Get local py2hwsw root from `PY2HWSW_ROOT` env variable
   py2hwswRoot = builtins.getEnv "PY2HWSW_ROOT";
 
@@ -24,13 +24,18 @@ let
             # Root provided, use local
             pkgs.lib.cleanSource py2hwswRoot
           else
-            # No root provided, use GitHub
+            # No root provided: fetch from GitHub and add shortHash.tex
             (pkgs.fetchFromGitHub {
               owner = "IObundle";
               repo = "py2hwsw";
               rev = py2hwsw_commit;
               sha256 = py2hwsw_sha256;
               fetchSubmodules = true;
+	      # Generate shortHash.tex based on commit
+              postFetch = ''
+                echo "Creating shortHash.tex"
+                echo "${builtins.substring 0 7 py2hwsw_commit}" > "$out/py2hwsw/shortHash.tex"
+              '';
             }).overrideAttrs (_: {
               GIT_CONFIG_COUNT = 1;
               GIT_CONFIG_KEY_0 = "url.https://github.com/.insteadOf";

--- a/default.nix
+++ b/default.nix
@@ -5,8 +5,8 @@
 { pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/25.05.tar.gz") {} }:
 
 let
-  py2hwsw_commit = "4ce6c2ab15d270b3a0e58c4f2d3cab5c40cfe85a"; # Replace with the desired commit.
-  py2hwsw_sha256 = "Wq9DEjw3Df0PoraZm5v1TL45nNqYueAUdXXeAVkYMy4="; # Replace with the actual SHA256 hash.
+  py2hwsw_commit = "9ebb39d014789af2753c9f372a315c0dd8bbea36"; # Replace with the desired commit.
+  py2hwsw_sha256 = "zAO2xAnmryLebpzY8SUEQnX0gKLhZbLNWsrHzAERfjQ="; # Replace with the actual SHA256 hash.
   # Get local py2hwsw root from `PY2HWSW_ROOT` env variable
   py2hwswRoot = builtins.getEnv "PY2HWSW_ROOT";
 
@@ -31,7 +31,7 @@ let
               rev = py2hwsw_commit;
               sha256 = py2hwsw_sha256;
               fetchSubmodules = true;
-	      # Generate shortHash.tex based on commit
+              # Generate shortHash.tex based on commit
               postFetch = ''
                 echo "Creating shortHash.tex"
                 echo "${builtins.substring 0 7 py2hwsw_commit}" > "$out/py2hwsw/shortHash.tex"

--- a/default.nix
+++ b/default.nix
@@ -5,8 +5,8 @@
 { pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/25.05.tar.gz") {} }:
 
 let
-  py2hwsw_commit = "9ebb39d014789af2753c9f372a315c0dd8bbea36"; # Replace with the desired commit.
-  py2hwsw_sha256 = "zAO2xAnmryLebpzY8SUEQnX0gKLhZbLNWsrHzAERfjQ="; # Replace with the actual SHA256 hash.
+  py2hwsw_commit = "14706890a5b37346a8f3464d06de25f5ea06f540"; # Replace with the desired commit.
+  py2hwsw_sha256 = "sJtvkluyQDxRAjbPHgi2YV5v1uc/4zqCuekEQ8crDTY="; # Replace with the actual SHA256 hash.
   # Get local py2hwsw root from `PY2HWSW_ROOT` env variable
   py2hwswRoot = builtins.getEnv "PY2HWSW_ROOT";
 

--- a/default.nix
+++ b/default.nix
@@ -5,8 +5,8 @@
 { pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/25.05.tar.gz") {} }:
 
 let
-  py2hwsw_commit = "14706890a5b37346a8f3464d06de25f5ea06f540"; # Replace with the desired commit.
-  py2hwsw_sha256 = "sJtvkluyQDxRAjbPHgi2YV5v1uc/4zqCuekEQ8crDTY="; # Replace with the actual SHA256 hash.
+  py2hwsw_commit = "cfb49c6c5c0b1ea7ae2a19c7766ba3a5a26f0179"; # Replace with the desired commit.
+  py2hwsw_sha256 = "yxKfQqQ6T3XYH5fImIfuQUhS2VMjeL+ov3yxmEpbJnY="; # Replace with the actual SHA256 hash.
   # Get local py2hwsw root from `PY2HWSW_ROOT` env variable
   py2hwswRoot = builtins.getEnv "PY2HWSW_ROOT";
 

--- a/linux_targets.mk
+++ b/linux_targets.mk
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: 2025 IObundle
+#
+# SPDX-License-Identifier: MIT
+
+#
+# Configuration variables
+#
+
+# Path of cloned iob-linux repository
+LINUX_REPO_DIR ?=
+# Name and build directory path of the linux-compatible peripheral core
+CORE_BUILD_DIR ?=
+# Build directory of pre-built linux system
+SOC_LINUX_BUILD_DIR ?=
+# Target FPGA board
+BOARD ?= iob_cyclonev_gt_dk
+
+$(info [linux_targets.mk]: LINUX_REPO_DIR: $(LINUX_REPO_DIR), CORE_BUILD_DIR: $(CORE_BUILD_DIR), SOC_LINUX_BUILD_DIR: $(SOC_LINUX_BUILD_DIR), BOARD: $(BOARD))
+
+
+#
+# Automatic variables
+#
+# Generate relative paths
+ifneq ($(CORE_BUILD_DIR),)
+REL_LINUX2BUILD :=`realpath $(CORE_BUILD_DIR) --relative-to=$(LINUX_REPO_DIR)`
+
+CORE=$(shell grep '^NAME=' $(CORE_BUILD_DIR)/config_build.mk | cut -d '=' -f 2)
+endif
+
+# Find board directoy inside hardware/fpga
+BOARD_DIR := $(shell find $(SOC_LINUX_BUILD_DIR)/hardware/fpga -name $(BOARD) -type d -print -quit)
+# Include board.mk to set BOARD_USER, BOARD_SERVER, and BOARD_SERIAL_PORT
+ifneq ($(BOARD_DIR),)
+include $(BOARD_DIR)/board.mk
+endif
+# Configure ssh if running on remote machines
+ifneq ($(BOARD_SERVER),)
+SSH_START=ssh $(BOARD_USER)@$(BOARD_SERVER) '
+SSH_END='
+REMOTE_BUILD_DIR?=$(USER)/$(notdir $(SOC_LINUX_BUILD_DIR))
+REMOTE_CORE_DIR?=$(USER)/$(notdir $(CORE_BUILD_DIR))
+else
+REMOTE_BUILD_DIR=$(SOC_LINUX_BUILD_DIR)
+REMOTE_CORE_DIR?=$(CORE_BUILD_DIR)
+endif
+# Assume a serial port if not specified
+ifeq ($(BOARD_SERIAL_PORT),)
+BOARD_SERIAL_PORT=/dev/usb-uart
+endif
+
+#
+# Targets
+#
+
+kernel-module-rebuild:
+	# Compile userspace binaries
+	nix-shell $(LINUX_REPO_DIR) --run 'make -C $(CORE_BUILD_DIR)/software/linux/user all'
+	# Compile kernel driver
+	nix-shell $(LINUX_REPO_DIR) --run 'make -C $(LINUX_REPO_DIR) build-linux-drivers MODULE_NAME=$(CORE) MODULE_DRIVER_DIR=$(REL_LINUX2BUILD)/software/linux/drivers ROOTFS_OVERLAY_DIR=$(REL_LINUX2BUILD)/software/linux/drivers'
+ifneq ($(BOARD_SERVER),)
+	# Rsync build dir to remote machine
+	rsync $(BOARD_SYNC_FLAGS) -avz --force --delete --exclude 'software/tb' $(CORE_BUILD_DIR)/ $(BOARD_USER)@$(BOARD_SERVER):$(REMOTE_CORE_DIR)/
+endif
+	# 1) Upload kernel module and user space binaries to running linux instance using lrzsz
+	# 2) Reload kernel module in running instance
+	#
+	# NOTE: These commands dont use board_client.py to grab the FPGA board. May cause conflicts with shared FPGAs.
+	# They dont grab the board, since its meant to be used with an already grabbed fpga running a linux instance.
+	$(SSH_START) cd $(REMOTE_CORE_DIR)/software/linux;\
+	stty -F /dev/usb-uart 115200 raw -echo -crtscts;\
+	echo "rz -o /drivers" > $(BOARD_SERIAL_PORT) && sz -y drivers/$(CORE).ko < $(BOARD_SERIAL_PORT) > $(BOARD_SERIAL_PORT);\
+	`# Uncomment this for block to enable transfer of user-space binaries\
+	for file in "$(CORE)_user_sysfs" "$(CORE)_user_dev" "$(CORE)_user_ioctl" "$(CORE)_tests_sysfs" "$(CORE)_tests_dev" "$(CORE)_tests_ioctl"; do\
+		echo "rz -o /root" > $(BOARD_SERIAL_PORT) && sz -y user/$$file < $(BOARD_SERIAL_PORT) > $(BOARD_SERIAL_PORT);\
+	done; `\
+	echo "modprobe /drivers/$(CORE).ko" > $(BOARD_SERIAL_PORT) $(SSH_END)
+
+.PHONY: kernel-module-rebuild
+
+# Set TERM variable to linux-c-nc (needed to run in non-interactive mode https://stackoverflow.com/a/49077622)
+TERM_STR:=TERM=linux-c-nc
+# Set HOME to current (fpga) directory (needed because minicom always reads the '.minirc.*' config file from HOME)
+HOME_STR:=HOME=$(REMOTE_BUILD_DIR)/hardware/fpga
+SCRIPT_STR:=-S minicom_linux_script.txt
+# Set a capture file and print its contents (to work around minicom clearing the screen)
+LOG_STR:=-C minicom_out.log $(FAKE_STDOUT) || cat minicom_out.log
+rerun-tests:
+	$(SSH_START) cd $(REMOTE_BUILD_DIR)/hardware/fpga;\
+	$(HOME_STR) $(TERM_STR) minicom iobundle.dfl $(SCRIPT_STR) $(LOG_STR) $(SSH_END)
+
+.PHONY: rerun-tests

--- a/soc_linux.py
+++ b/soc_linux.py
@@ -18,6 +18,9 @@ def setup(py_params: dict):
             # check the 'cpu' python parameter at: https://github.com/IObundle/py2hwsw/blob/main/py2hwsw/lib/iob_system/iob_system.py
             "cpu": "iob_vexriscv",
             #
+            # Do not include Tester system to speed-up setup process
+            "include_tester": False,
+            #
             # NOTE: Place other iob_system_linux python parameters here
             # "some_iob_system_linux_param": "my_value",
             **py_params,


### PR DESCRIPTION
- Update Py2HWSW with latest features from https://github.com/IObundle/py2hwsw/pull/425;
- Add `linux_targets.mk` makefile segment with two new targets:
  - kernel-module-rebuild: Rebuild linux kernel modules of a given peripheral core and upload it to running linux system.
  - rerun-tests: Relaunch minicom script in running linux system.