### PR TITLE
Fix linux Makefile targets; Update Py2HWSW.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,8 +5,8 @@
 { pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/25.05.tar.gz") {} }:
 
 let
-  py2hwsw_commit = "cfb49c6c5c0b1ea7ae2a19c7766ba3a5a26f0179"; # Replace with the desired commit.
-  py2hwsw_sha256 = "yxKfQqQ6T3XYH5fImIfuQUhS2VMjeL+ov3yxmEpbJnY="; # Replace with the actual SHA256 hash.
+  py2hwsw_commit = "19bd46b468cfe343bf1f1fcf268151434757c042"; # Replace with the desired commit.
+  py2hwsw_sha256 = "3vHUR/oHXLNtsyVlKieH1q1zI2MvwsrUq0qtyA6iIfQ="; # Replace with the actual SHA256 hash.
   # Get local py2hwsw root from `PY2HWSW_ROOT` env variable
   py2hwswRoot = builtins.getEnv "PY2HWSW_ROOT";
 

--- a/linux_targets.mk
+++ b/linux_targets.mk
@@ -74,19 +74,18 @@ endif
 	for file in "$(CORE)_user_sysfs" "$(CORE)_user_dev" "$(CORE)_user_ioctl" "$(CORE)_tests_sysfs" "$(CORE)_tests_dev" "$(CORE)_tests_ioctl"; do\
 		echo "rz -o /root" > $(BOARD_SERIAL_PORT) && sz -y user/$$file < $(BOARD_SERIAL_PORT) > $(BOARD_SERIAL_PORT);\
 	done; `\
-	echo "modprobe /drivers/$(CORE).ko" > $(BOARD_SERIAL_PORT) $(SSH_END)
+	echo "rmmod $(CORE); insmod /drivers/$(CORE).ko" > $(BOARD_SERIAL_PORT) $(SSH_END)
 
 .PHONY: kernel-module-rebuild
 
 # Set TERM variable to linux-c-nc (needed to run in non-interactive mode https://stackoverflow.com/a/49077622)
 TERM_STR:=TERM=linux-c-nc
-# Set HOME to current (fpga) directory (needed because minicom always reads the '.minirc.*' config file from HOME)
-HOME_STR:=HOME=$(REMOTE_BUILD_DIR)/hardware/fpga
 SCRIPT_STR:=-S minicom_linux_script.txt
 # Set a capture file and print its contents (to work around minicom clearing the screen)
 LOG_STR:=-C minicom_out.log $(FAKE_STDOUT) || cat minicom_out.log
 rerun-tests:
+	# Set HOME to current (fpga) directory (needed because minicom always reads the '.minirc.*' config file from HOME)
 	$(SSH_START) cd $(REMOTE_BUILD_DIR)/hardware/fpga;\
-	$(HOME_STR) $(TERM_STR) minicom iobundle.dfl $(SCRIPT_STR) $(LOG_STR) $(SSH_END)
+	HOME=$$PWD $(TERM_STR) minicom iobundle.dfl $(SCRIPT_STR) $(LOG_STR) $(SSH_END)
 
 .PHONY: rerun-tests


### PR DESCRIPTION
- Fix HOME variable for minicom; Use rmmod/insmod instead of modprobe to reload kernel module. 605235ace3a73137e089cee85222f94f827d3096
- Update py2hwsw version with latest fixes from https://github.com/IObundle/py2hwsw/pull/425