### PR TITLE
Add Linux UART16550 validation tests

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,8 +5,8 @@
 { pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/25.05.tar.gz") {} }:
 
 let
-  py2hwsw_commit = "b79eeae6019e84c31a20be4ce8c1cebbe8388c81"; # Replace with the desired commit.
-  py2hwsw_sha256 = "hEh9O4KnrKO+9YCrUfRyWsdwEIF7ppPcQt2W+HUlRIE="; # Replace with the actual SHA256 hash.
+  py2hwsw_commit = "21b1f2db283dc72d3ad62995f3457c16f77592b0"; # Replace with the desired commit.
+  py2hwsw_sha256 = "XmNwIx3p5uhjueZ5vlNZvZbrR1ja2UiQ+B22ekFDxdI="; # Replace with the actual SHA256 hash.
   # Get local py2hwsw root from `PY2HWSW_ROOT` env variable
   py2hwswRoot = builtins.getEnv "PY2HWSW_ROOT";
 

--- a/hardware/fpga/child2_fpga_build.mk
+++ b/hardware/fpga/child2_fpga_build.mk
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 IObundle
+# SPDX-FileCopyrightText: 2026 IObundle
 #
 # SPDX-License-Identifier: MIT
 
@@ -10,6 +10,14 @@ UFLAGS+=CACHE_DEMO=$(CACHE_DEMO)
 ifeq ($(CACHE_DEMO),1)
 # Override default linux minicom script to run cache demo instead
 MINICOM_SCRIPT=minicom_cache_demo.txt
+endif
+
+# Pass UART_DEMO flag to remote systems
+UFLAGS+=UART_DEMO=$(UART_DEMO)
+
+ifeq ($(UART_DEMO),1)
+# Override default linux minicom script to run cache demo instead
+MINICOM_SCRIPT=minicom_uart_demo.txt
 endif
 
 # include fpga build segment of (level 3) child systems

--- a/hardware/fpga/minicom_uart_demo.txt
+++ b/hardware/fpga/minicom_uart_demo.txt
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2026 IObundle
+#
+# SPDX-License-Identifier: MIT
+
+# Script for "runscript" program of minicom, to test two iob_uart16550 instances in linux
+
+# Set 15min timeout
+# runscript has 2min timeout by default:
+# check `timeout` in: https://linux.die.net/man/1/runscript
+timeout 900
+
+# Wait for the "buildroot login:" message
+# Or jump straight to shell if we are already logged in
+print "\n[minicom] Waiting for buildroot login..."
+send ""
+expect {
+    "buildroot login:"
+    "\n#" goto post_login
+    timeout 300 goto on_timeout
+}
+
+print "\n[minicom] Detected login prompt. Logging in..."
+
+send "root"
+
+expect {
+    "#"
+    timeout 20 goto on_timeout
+}
+
+post_login:
+
+#
+# Run tests
+#
+
+print "\n[minicom] Logged in. Running tests..."
+
+print "\n[minicom] Test communication between two iob_uart16550 periherals using '8250/16550' Linux driver"
+send "./uart16550/validate_uart.sh"
+expect {
+    "#"
+    timeout 30 goto on_timeout
+}
+
+#
+# Tests complete
+#
+
+# Send test.log
+send "echo 'Test passed!' > test.log"
+send "sz -e test.log"
+! rz --overwrite
+
+print "\n[minicom] Done Test"
+
+# Exit minicom
+! kill `cut -f4 -d' ' /proc/$PPID/stat`
+
+
+# Jump here when timeout is triggered
+on_timeout:
+
+print "\n[minicom] Timeout reached. Exiting..."
+
+# Exit minicom
+! kill `cut -f4 -d' ' /proc/$PPID/stat`
+
+

--- a/soc_linux.py
+++ b/soc_linux.py
@@ -5,7 +5,7 @@
 
 def setup(py_params: dict):
     # Include CACHE and DMA peripherals for demonstration
-    CACHE_DEMO = py_params.get("cache_demo", 0)
+    CACHE_DEMO = int(py_params.get("cache_demo", 0))
 
     # Attributes to pass to parent SoC (iob_system_linux), overriding inherited defaults.
     override_attributes = {}

--- a/software/sw_build.mk
+++ b/software/sw_build.mk
@@ -9,9 +9,11 @@ ROOT_DIR ?=..
 
 include $(ROOT_DIR)/software/auto_sw_build.mk
 
+ifneq ($(filter iob_cache,$(PERIPHERALS)),)
 # Filter out iob_cache from PERIPHERALS list, since its correct generated name is iob_cache_axi
 PERIPHERALS:=$(filter-out iob_cache,$(PERIPHERALS))
 PERIPHERALS+=iob_cache_axi
+endif
 
 # Local embedded makefile settings for custom bootloader and firmware targets.
 


### PR DESCRIPTION
## Please create tag M3_b after merging this PR.
Updated Py2HWSW to latest version: https://github.com/IObundle/py2hwsw/pull/433

To try it out, run the following commands:
```
# Generate and run the SoCLinux system in the aes_ku040_db_g FPGA board:
make fpga-build fpga-run BOARD=iob_aes_ku040_db_g

# Run the Linux OS on the FPGA board:
# The system will automatically launch the UART validation tests upon boot.
make fpga-run BOARD=iob_aes_ku040_db_g RUN_LINUX=1 UART_DEMO=1
```